### PR TITLE
 Adds ToList<T>(IEnumerable<T>)

### DIFF
--- a/ShittyLINQ/ToList.cs
+++ b/ShittyLINQ/ToList.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShittyLINQ
+{
+    public static partial class Extensions
+    {
+        public static List<T> ToList<T>(this IEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException();
+            Func<List<T>, T, List<T>> toList = (memo, value) => { memo.Add(value); return memo; };
+            return source.Foldl(new List<T>(), toList);
+        }
+    }
+}

--- a/ShittyLinqTests/ToListTests.cs
+++ b/ShittyLinqTests/ToListTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ShittyLINQ;
+using ShittyTests.TestHelpers;
+using System;
+using System.Collections.Generic;
+
+namespace ShittyLinqTests
+{
+    [TestClass]
+    public class ToListTests
+    {
+        [TestMethod]
+        public void ToList_SequenceIsNull()
+        {
+            IEnumerable<int> nums = null;
+            Assert.ThrowsException<ArgumentNullException>(() => nums.ToList());
+        }
+
+        [TestMethod]
+        public void ToList_SequenceEquals()
+        {
+            var expected = new int[] { 0, 1, 2 };
+            var actual = expected.ToList();
+            TestHelper.AssertCollectionsAreSame(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Adds the heavily abused .ToList() method.
CC -> #4 