### PR TITLE
Added SelectMany method

### DIFF
--- a/ShittyLINQ/Enumerable/Range.cs
+++ b/ShittyLINQ/Enumerable/Range.cs
@@ -15,7 +15,7 @@ namespace ShittyLINQ
                 throw new ArgumentOutOfRangeException("Count must be a non-negative integer.");
             }
 
-            if (int.MaxValue - start + 1 < count)
+            if (count - 1 > int.MaxValue - start)
             {
                 throw new ArgumentOutOfRangeException("Generates integers that are larger than the maximum value.");
             }

--- a/ShittyLINQ/Select.cs
+++ b/ShittyLINQ/Select.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace ShittyLINQ
 {

--- a/ShittyLINQ/SelectMany.cs
+++ b/ShittyLINQ/SelectMany.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ShittyLINQ
+{
+    public static partial class Extensions
+    {
+        public static IEnumerable<U> SelectMany<T, U>(this IEnumerable<T> source, Func<T, IEnumerable<U>> selector)
+        {
+            if (source == null || selector == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            Func<List<U>, T, List<U>> iterator = (memo, val) =>
+            {
+                memo.AddRange(selector(val));
+
+                return memo;
+            };
+
+            return source.Foldl(new List<U>((int)source.Count()), iterator);
+        }
+    }
+}

--- a/ShittyLinqTests/EnumerableTests.cs
+++ b/ShittyLinqTests/EnumerableTests.cs
@@ -23,10 +23,10 @@ namespace ShittyTests
         public void Range_ArgumentOutOfRangeException()
         {
             // Over int.MaxValue
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Enumerable.Range(int.MaxValue - 1, 2));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Enumerable.Range(int.MaxValue, 2).ToList());
 
             // Negative count
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Enumerable.Range(0, -1));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => Enumerable.Range(0, -1).ToList());
         }
     }
 }

--- a/ShittyLinqTests/SelectManyTests.cs
+++ b/ShittyLinqTests/SelectManyTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ShittyLINQ;
+using ShittyTests.TestHelpers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShittyTests
+{
+    [TestClass]
+    public class SelectManyTests
+    {
+        [TestMethod]
+        public void SelectMany_Flatten()
+        {
+            IEnumerable<IEnumerable<int>> numbers = new[] { new[] { 1, 2, 3 }, new[] { 4 } };
+            IEnumerable<int> expected = new[] { 1, 2, 3, 4 };
+
+            IEnumerable<int> actual = numbers.SelectMany(i => i);
+
+            TestHelper.AssertCollectionsAreSame(expected, actual);
+        }
+
+        [TestMethod]
+        public void SelectMany_ThrowsArgumentNullException()
+        {
+            IEnumerable<IEnumerable<int>> numbers = null;
+
+            Assert.ThrowsException<ArgumentNullException>(() => numbers.SelectMany(i => i));
+
+            numbers = new[] { new[] { 1, 2, 3 } };
+            Func<IEnumerable<int>, IEnumerable<int>> selector = null;
+
+            Assert.ThrowsException<ArgumentNullException>(() => numbers.SelectMany(selector));
+        }
+    }
+}


### PR DESCRIPTION
From this [spec](https://msdn.microsoft.com/en-us/library/bb534336(v=vs.110).aspx).

SelectMany has other overrides that were not implemented:

- [ ] [`Enumerable.SelectMany<TSource, TResult> Method (IEnumerable<TSource>, Func<TSource, Int32, IEnumerable<TResult>>)`](https://msdn.microsoft.com/en-us/library/bb549142(v=vs.110).aspx)
- [ ] [`Enumerable.SelectMany<TSource, TCollection, TResult> Method (IEnumerable<TSource>, Func<TSource, IEnumerable<TCollection>>, Func<TSource, TCollection, TResult>)`](https://msdn.microsoft.com/en-us/library/bb534631(v=vs.110).aspx)
- [ ] [`Enumerable.SelectMany<TSource, TCollection, TResult> Method (IEnumerable<TSource>, Func<TSource, Int32, IEnumerable<TCollection>>, Func<TSource, TCollection, TResult>)`](https://msdn.microsoft.com/en-us/library/bb534732(v=vs.110).aspx)