### PR TITLE
Adds Zip method.

### DIFF
--- a/ShittyLINQ/Zip.cs
+++ b/ShittyLINQ/Zip.cs
@@ -5,6 +5,16 @@ namespace ShittyLINQ
 {
     public static partial class Extensions
     {
+        /// <summary>
+        /// <para>
+        /// Combines two Enumerable objects into a sequence of Tuples containing each element
+        /// of the source Enumerable in the first position with the element that has the same
+        /// index in the second Enumerable in the second position.
+        /// </para>
+        /// <para>
+        /// The output sequence will be as long as the shortest input sequence.
+        /// </para>
+        /// </summary>
         public static IEnumerable<Tuple<T, U>> Zip<T, U>(this IEnumerable<T> source, IEnumerable<U> second)
         {
             if (source == null || second == null) throw new ArgumentNullException();

--- a/ShittyLINQ/Zip.cs
+++ b/ShittyLINQ/Zip.cs
@@ -15,7 +15,7 @@ namespace ShittyLINQ
         /// The output sequence will be as long as the shortest input sequence.
         /// </para>
         /// </summary>
-        public static IEnumerable<Tuple<T, U>> Zip<T, U>(this IEnumerable<T> source, IEnumerable<U> second)
+        public static IEnumerable<(T, U)> Zip<T, U>(this IEnumerable<T> source, IEnumerable<U> second)
         {
             if (source == null || second == null) throw new ArgumentNullException();
 
@@ -24,7 +24,7 @@ namespace ShittyLINQ
 
             while(firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
             {
-                yield return Tuple.Create(firstEnumerator.Current, secondEnumerator.Current);
+                yield return (firstEnumerator.Current, secondEnumerator.Current);
             }
         }
     }

--- a/ShittyLINQ/Zip.cs
+++ b/ShittyLINQ/Zip.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ShittyLINQ
+{
+    public static partial class Extensions
+    {
+        public static IEnumerable<Tuple<T, U>> Zip<T, U>(this IEnumerable<T> source, IEnumerable<U> second)
+        {
+            if (source == null || second == null) throw new ArgumentNullException();
+
+            var firstEnumerator = source.GetEnumerator();
+            var secondEnumerator = second.GetEnumerator();
+
+            while(firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+            {
+                yield return Tuple.Create(firstEnumerator.Current, secondEnumerator.Current);
+            }
+        }
+    }
+}

--- a/ShittyLinqTests/ZipTests.cs
+++ b/ShittyLinqTests/ZipTests.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using ShittyLINQ;
 
 namespace ShittyTests
@@ -16,13 +14,13 @@ namespace ShittyTests
             char[] second = new[] { 'w', 'o', 'r', 'l', 'd' };
 
             var actual = source.Zip(second).ToList();
-            var expected = new Tuple<char, char>[]
+            var expected = new (char, char)[]
             {
-                Tuple.Create('h', 'w'),
-                Tuple.Create('e', 'o'),
-                Tuple.Create('l', 'r'),
-                Tuple.Create('l', 'l'),
-                Tuple.Create('o', 'd'),
+                ('h', 'w'),
+                ('e', 'o'),
+                ('l', 'r'),
+                ('l', 'l'),
+                ('o', 'd'),
             };
 
             CollectionAssert.AreEqual(expected, actual);

--- a/ShittyLinqTests/ZipTests.cs
+++ b/ShittyLinqTests/ZipTests.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ShittyLINQ;
+
+namespace ShittyTests
+{
+    [TestClass]
+    public class ZipTests
+    {
+        [TestMethod]
+        public void Zip_ItemsMatchUp()
+        {
+            char[] source = new[] { 'h', 'e', 'l', 'l', 'o' };
+            char[] second = new[] { 'w', 'o', 'r', 'l', 'd' };
+
+            var actual = source.Zip(second).ToList();
+            var expected = new Tuple<char, char>[]
+            {
+                Tuple.Create('h', 'w'),
+                Tuple.Create('e', 'o'),
+                Tuple.Create('l', 'r'),
+                Tuple.Create('l', 'l'),
+                Tuple.Create('o', 'd'),
+            };
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Zip_SourceIsLonger()
+        {
+            int[] source = new[] { 0, 1, 2, 3 };
+            int[] second = new[] { 0, 1, 2 };
+
+            var actual = source.Zip(second).Count();
+            var expected = 3L;
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Zip_SecondIsLonger()
+        {
+            int[] source = new[] { 0, 1, 2 };
+            int[] second = new[] { 0, 1, 2, 3 };
+
+            var actual = source.Zip(second).Count();
+            var expected = 3L;
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void Zip_SourceIsNull()
+        {
+            int[] a = null;
+            int[] b = new[] { 0, 1, 2 };
+
+            Assert.ThrowsException<ArgumentNullException>(() => a.Zip(b).ToList());
+        }
+
+        [TestMethod]
+        public void Zip_SecondIsNull()
+        {
+            int[] a = new[] { 0, 1, 2 };
+            int[] b = null;
+
+            Assert.ThrowsException<ArgumentNullException>(() => a.Zip(b).ToList());
+        }
+
+        [TestMethod]
+        public void Zip_BothAreNull()
+        {
+            int[] a = null;
+            int[] b = null;
+
+            Assert.ThrowsException<ArgumentNullException>(() => a.Zip(b).ToList());
+        }
+    }
+}


### PR DESCRIPTION
This implementation deviates from [the spec](https://msdn.microsoft.com/en-us/library/dd267698(v=vs.110).aspx) in that it does not accept a transform function and outputs a sequence of Tuples by default. This is more in-line with most implementations of `Zip`.

An implementation of this method that does accept a transform function should be added at a later time and should be called `ZipWith`.