### PR TITLE
Impelement SingleOrDefault

### DIFF
--- a/ShittyLINQ/SingleOrDefault.cs
+++ b/ShittyLINQ/SingleOrDefault.cs
@@ -6,7 +6,7 @@ namespace ShittyLINQ
     public static partial class Extensions
     {
         /// <summary>
-        /// Returns the first element of the sequence 
+        /// Returns only one element of the sequence 
         /// or the default value of the type if the collection is empty.
         /// </summary>
         /// <typeparam name="TSource">The type of the items in the sequence</typeparam>
@@ -20,10 +20,58 @@ namespace ShittyLINQ
             var enumerator = source.GetEnumerator();
             if (enumerator.MoveNext())
             {
-                return enumerator.Current;
+                var first = enumerator.Current;
+
+                if (enumerator.MoveNext())
+                {
+                    throw new InvalidOperationException();
+                }
+                else
+                {
+                    return first;
+                }
             }
 
             return default(TSource);
+        }
+
+        /// <summary>
+        /// Returns only one element of the sequence that meets the predicate  
+        /// or the default value of the type.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the items in the sequnce.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="predicate">The predicate on which the items are evaluated.</param>
+        /// <returns></returns>
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            TSource first = default(TSource);
+            bool firstIsSet = false;
+
+            var enumerator = source.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                if (predicate(enumerator.Current))
+                {
+                    if (firstIsSet)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                    else
+                    {
+                        first = enumerator.Current;
+                        firstIsSet = true;
+                    }
+                }
+            }
+
+            return first;
         }
     }
 }

--- a/ShittyLINQ/SingleOrDefault.cs
+++ b/ShittyLINQ/SingleOrDefault.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ShittyLINQ
+{
+    public static partial class Extensions
+    {
+        /// <summary>
+        /// Returns the first element of the sequence 
+        /// or the default value of the type if the collection is empty.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the items in the sequence</typeparam>
+        /// <param name="source">The source sequence</param>
+        /// <returns></returns>
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            var enumerator = source.GetEnumerator();
+            if (enumerator.MoveNext())
+            {
+                return enumerator.Current;
+            }
+
+            return default(TSource);
+        }
+    }
+}

--- a/ShittyLinqTests/SingleOrDefaultTests.cs
+++ b/ShittyLinqTests/SingleOrDefaultTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace ShittyTests
+{
+    [TestClass]
+    public class SingleOrDefaultTests
+    {
+        [TestMethod]
+        public void SingleOrDefault_ReturnsTheFirstElementIfCollectionIsNotEmpty()
+        {
+            var expected = 42;
+            var collection = new int[] { 42, 1, 99 };
+
+            var first = collection.FirstOrDefault();
+            Assert.AreEqual(expected, first);
+        }
+
+        [TestMethod]
+        public void SingleOrDefault_ReturnsDefaultValueIfCollectionIsEmpty()
+        {
+            var collection = new int[] { };
+
+            var first = collection.FirstOrDefault();
+            Assert.AreEqual(default(int), first);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SingleOrDefault_ThrowsIfSourceIsNull()
+        {
+            IOrderedEnumerable<int> collection = null;
+            var first = collection.FirstOrDefault();
+        }
+    }
+}

--- a/ShittyLinqTests/SingleOrDefaultTests.cs
+++ b/ShittyLinqTests/SingleOrDefaultTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ShittyTests
@@ -11,9 +12,9 @@ namespace ShittyTests
         public void SingleOrDefault_ReturnsTheFirstElementIfCollectionIsNotEmpty()
         {
             var expected = 42;
-            var collection = new int[] { 42, 1, 99 };
+            var collection = new int[] { 42 };
 
-            var first = collection.FirstOrDefault();
+            var first = collection.SingleOrDefault();
             Assert.AreEqual(expected, first);
         }
 
@@ -22,7 +23,7 @@ namespace ShittyTests
         {
             var collection = new int[] { };
 
-            var first = collection.FirstOrDefault();
+            var first = collection.SingleOrDefault();
             Assert.AreEqual(default(int), first);
         }
 
@@ -30,8 +31,59 @@ namespace ShittyTests
         [ExpectedException(typeof(ArgumentNullException))]
         public void SingleOrDefault_ThrowsIfSourceIsNull()
         {
-            IOrderedEnumerable<int> collection = null;
-            var first = collection.FirstOrDefault();
+            IEnumerable<int> collection = null;
+            var first = collection.SingleOrDefault();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void SingleOrDefault_ThrowsIfMoreThanOneElementInSequence()
+        {
+            var collection = new int[] { 42, 24 };
+            var first = collection.SingleOrDefault();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SingleOrDefault_SecondOverloadThrowsIfSourceIsNull()
+        {
+            IEnumerable<int> collection = null;
+            var first = collection.SingleOrDefault(i => i > 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SingleOrDefault_SecondOverloadThrowsIfPredicateIsNull()
+        {
+            IEnumerable<int> collection = new int[] { 42 };
+            var first = collection.SingleOrDefault(null);
+        }
+
+        [TestMethod]
+        public void SingleOrDefault_SecondOverloadReturnsTheFirstElementIfCollectionIsNotEmpty()
+        {
+            var expected = 42;
+            var collection = new int[] { 42, 142, 242 };
+
+            var first = collection.SingleOrDefault(i => i < 100);
+            Assert.AreEqual(expected, first);
+        }
+
+        [TestMethod]
+        public void SingleOrDefault_SecondOverloadReturnsDefaultValueIfCollectionIsEmpty()
+        {
+            var collection = new int[] { 142, 242 };
+
+            var first = collection.SingleOrDefault(i => i < 100);
+            Assert.AreEqual(default(int), first);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void SingleOrDefault_SecondOverloadThrowsIfMoreThanOneElementInSequence()
+        {
+            var collection = new int[] { 42, 24 };
+            var first = collection.SingleOrDefault(i => i < 100);
         }
     }
 }


### PR DESCRIPTION
This PR implements both of the overloads of [SingleOrDefault](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.singleordefault?view=netframework-4.7.2) and the required unit tests. Closes #61 